### PR TITLE
Add support for arbitrary header configuration

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -58,6 +58,20 @@ Serving compressed files
 If a gzip compressed file with the ´gz´ postfix is present, it is served, along with the corresponding headers.
 So if the file 'index.html' and the file 'index.html.gz' are present, the file 'index.html.gz' is served, if the the client indicated that it supports gzipped content.
 
+Additionally, you can configure arbitrary headers. You can match files by mime
+type, file extension, or prefix. For example, the following would add
+Cache-Control headers to paths with a css mime type for 10s, no-cache for all
+paths ending in .js for 100s, and add CORS header to all paths under the /imgs/
+dir::
+
+    headers = [
+        {'type': 'text/css', 'Cache-Control': 'max-age=10'},
+        {'ext': '.js', 'Cache-Control': 'no-cache'},
+        {'prefix': '/imgs/', 'Access-Control-Allow-Origin': '*'},
+    ]
+    Cling("/my/directory", headers=headers)
+
+
 Shock
 ^^^^^
 

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -105,6 +105,35 @@ def test_gzip_cling(cling):
     assert response.headers['Vary'] == 'Accept-Encoding'
 
 
+def test_headers_cling():
+    from static import Cling
+
+    def get(headers, url='/index.html'):
+        app = webtest.TestApp(Cling(root="testdata/pub", headers=headers))
+        return app.get(url)
+
+    response = get([{'type': 'text/html', 'Cache-Control': 'max-age=10'}])
+    assert response.headers['Cache-Control'] == 'max-age=10'
+
+    response = get(
+        [{'type': 'text/html', 'Cache-Control': 'max-age=10'}], '/test.xml')
+    assert 'Cache-Control' not in response.headers.keys()
+
+    response = get([{'ext': 'html', 'Cache-Control': 'max-age=10'}])
+    assert response.headers['Cache-Control'] == 'max-age=10'
+
+    response = get(
+        [{'ext': 'html', 'Cache-Control': 'max-age=10'}], '/test.xml')
+    assert 'Cache-Control' not in response.headers.keys()
+
+    response = get([{'prefix': '/index', 'Cache-Control': 'max-age=10'}])
+    assert response.headers['Cache-Control'] == 'max-age=10'
+
+    response = get(
+        [{'prefix': '/index', 'Cache-Control': 'max-age=10'}], '/test.xml')
+    assert 'Cache-Control' not in response.headers.keys()
+
+
 def test_static_shock(shock):
     response = shock.get("/index.html")
     assert "Mixed Content" in response


### PR DESCRIPTION
Adds a configuration parameter 'headers', which can add headers based on prefix, extension, and mime type.

Use case is to add Cache-Control and CORS headers to static files served by the app.

Also, synchronised python envs between tox and travis
