### PR TITLE
Decode the README as utf-8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,33 +1,11 @@
+sudo: false
 language: python
-
-python:
-  - "2.6"
-  - "2.7"
-  - "3.2"
-  - "3.3"
-  - "3.4"
-  - "pypy"
-
+install: pip install tox
 env:
-  - PIP_USE_MIRRORS=true DEPS="genshi"
-  - PIP_USE_MIRRORS=true DEPS="kid genshi"
-
-matrix:
-  exclude:
-    - python: "2.6"
-      env: PIP_USE_MIRRORS=true DEPS="genshi"
-    - python: "2.7"
-      env: PIP_USE_MIRRORS=true DEPS="genshi"
-    - python: "pypy"
-      env: PIP_USE_MIRRORS=true DEPS="genshi"
-    - python: "3.2"
-      env: PIP_USE_MIRRORS=true DEPS="kid genshi"
-    - python: "3.3"
-      env: PIP_USE_MIRRORS=true DEPS="kid genshi"
-    - python: "3.4"
-      env: PIP_USE_MIRRORS=true DEPS="kid genshi"
-
-install:
-  - "pip install $DEPS"
-
-script: "python setup.py test"
+  - TOXENV=py26
+  - TOXENV=py27
+  - TOXENV=py32
+  - TOXENV=py33
+  - TOXENV=py34
+  - TOXENV=pypy
+script: tox

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ setup(name='static3',
       version='0.6.0',
       description=
       'A really simple WSGI way to serve static (or mixed) content.',
-      long_description=open('README.rst').read(),
+      long_description=open('README.rst', 'rb').read().decode('utf-8'),
       author='Roman Mohr',
       author_email='roman@fenkhuber.at',
       url='https://github.com/rmohr/static3',

--- a/tox.ini
+++ b/tox.ini
@@ -1,17 +1,16 @@
 [tox]
-envlist = py27, py33
+envlist = py26, py27, py32, py33, py34, pypy
 
 [testenv]
-deps=distribute
+deps=
+    distribute
+    pytest
+    genshi
+    py{26,27},pypy: kid
 commands=python setup.py test []
 sitepackages=False
-
-[testenv:py27]
-deps=kid
-     genshi
-
-[testenv:py33]
-deps=genshi
+setenv=
+    PIP_USE_MIRRORS=true
 
 [pytest]
 norecursedirs = bin eggs .git _build tmp* lib *.egg


### PR DESCRIPTION
tox, in version 2, no longer passes environment variables from the calling environment. This causes problems, because the `LANG` environment variable is how Python attempts to figure out the locale, and defaults to ASCII. The `README.rst` file has utf-8 characters, and is read in the `setup.py`.

This means that right now this package cannot be installed under tox 2 with Python 3, unless tox is configured to pass that environment variable from the context.

Running the tests on Travis CI isn't catching this, because this problem doesn't show up without a limited environment, like we get from tox.