### PR TITLE
Explicitly set encoding of README file

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ setup(name='static3',
       version='0.6.0',
       description=
       'A really simple WSGI way to serve static (or mixed) content.',
-      long_description=open('README.rst').read(),
+      long_description=open('README.rst', encoding='utf-8').read(),
       author='Roman Mohr',
       author_email='roman@fenkhuber.at',
       url='https://github.com/rmohr/static3',


### PR DESCRIPTION
Currently, installation of the python package fails to install on systems with a misconfigured locale (i.e. one that is not set to ``UTF-8``). This is really annoying as it fails to install on some CI servers, including things like readthedocs.org.