### PR TITLE
Fix HEAD request returning string intead of bytes iterable

### DIFF
--- a/static.py
+++ b/static.py
@@ -187,7 +187,7 @@ class Cling(object):
                 return self._body(full_path, environ, file_like)
 
             else:
-                return ['']
+                return [_encode("", sys.getdefaultencoding())]
         except (IOError, OSError) as e:
             print(e)
             return self.not_found(environ, start_response)


### PR DESCRIPTION
python version: 3.4.4
static3 version 0.6.1

curl --head "http://localhost/static/img/favicon.ico"
`
curl: (52) Empty reply from server
`

Stacktrace:
```
Traceback (most recent call last):
  File "/usr/local/lib/python3.4/wsgiref/handlers.py", line 138, in run
    self.finish_response()
  File "/usr/local/lib/python3.4/wsgiref/handlers.py", line 180, in finish_response
    self.write(data)
  File "/usr/local/lib/python3.4/wsgiref/handlers.py", line 266, in write
    "write() argument must be a bytes instance"
```