### PR TITLE
Drop support for Python 3.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ install: pip install tox
 env:
   - TOXENV=py26
   - TOXENV=py27
-  - TOXENV=py32
   - TOXENV=py33
   - TOXENV=py34
   - TOXENV=pypy

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py26, py27, py32, py33, py34, pypy
+envlist = py26, py27, py33, py34, pypy
 
 [testenv]
 deps=


### PR DESCRIPTION
Virtualenv dropped support for Python 3.2.
See https://virtualenv.pypa.io/en/latest/changes.html#id9