### PR TITLE
Fix #8, return empty byte string on HEAD request

### DIFF
--- a/static.py
+++ b/static.py
@@ -187,7 +187,7 @@ class Cling(object):
                 return self._body(full_path, environ, file_like)
 
             else:
-                return ['']
+                return [b'']
         except (IOError, OSError) as e:
             print(e)
             return self.not_found(environ, start_response)
@@ -489,7 +489,8 @@ def test():
     from wsgiref.validate import validator
     magics = (StringMagic(title="String Test"),
               KidMagic(title="Kid Test"), GenshiMagic(title="Genshi Test"))
-    app = Shock('testdata/pub', magics=magics)
+    #app = Shock('testdata/pub', magics=magics)
+    app = Cling('testdata/pub')
     try:
         make_server('localhost', 9999, validator(app)).serve_forever()
     except KeyboardInterrupt:

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -19,7 +19,6 @@
 import pytest
 import webtest
 
-import sys
 from static import u
 
 
@@ -83,6 +82,18 @@ def test_static_cling(cling):
             or response.content_type == "application/xml")
     response = cling.get("/unicode.html")
     assert u('\u00f6\u00e4\u00fc') in response
+
+
+def test_cling_head(cling):
+    response = cling.head("/index.html")
+    assert response.content_type == "text/html"
+    assert response.body == b''
+
+
+def test_shock_head(shock):
+    response = shock.head("/index.html")
+    assert response.content_type == "text/html"
+    assert response.body == b''
 
 
 def test_gzip_cling(cling):


### PR DESCRIPTION
Python 3 WSGI requires byte strings as WSGI return values. Return an
empty byte string on a HTTP HEAD reqeust.